### PR TITLE
Fix wrong ServiceProvider name on README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Development
+## 1.0.6
 
 - Add keywords section to composer.json
 - Fix wrong ServiceProvider name on README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## 1.0.5
 
 - Fix README
+- Modify README, remove comma from composer.json part
 
 ## 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Development
 
 - Add keywords section to composer.json
+- Fix wrong ServiceProvider name on README
 
 ## 1.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Add keywords section to composer.json
 - Fix wrong ServiceProvider name on README
+- Add advanced usage section to README
 
 ## 1.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Development
+
+- Add keywords section to composer.json
+
 ## 1.0.5
 
 - Fix README

--- a/README.md
+++ b/README.md
@@ -43,7 +43,18 @@ php artisan vendor:publish --provider="Juy\CharacterSolver\ServiceProvider" --ta
 
 ## Usage
 
-No any usage instructions, package run automatically. You can enable/disable it on config file, after publish config.
+Package run automatically with a global middleware. You can enable/disable it on `config/charactersolver.php` config file, after publish package config.
+
+### Advanced usage
+
+If you want to use middleware at Kernel file:
+
+1. Publish package config and disable it on `config/charactersolver.php` config file (`'enabled' => false,`).
+2. Add the following code to `app/Http/Kernel.php` file, in web middleware groups.
+
+```
+\Juy\CharacterSolver\Middleware\CharacterSolver::class,
+```
 
 ----------
 

--- a/README.md
+++ b/README.md
@@ -48,4 +48,5 @@ No any usage instructions, package run automatically. You can enable/disable it 
 ----------
 
 ### License
+
 This project is open-sourced software licensed under the [MIT License](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 Add this package to your `composer.json` file and run `composer update` once.
 
 ```json
-"juy/character-solver": "1.*",
+"juy/character-solver": "1.*"
 ```
 
 ### Service provider

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Juy\CharacterSolver\ServiceProvider::class,
 If you need change or add different character, you can publish a config file.
 
 ```
-php artisan vendor:publish --provider="Juy\Providers\ServiceProvider" --tag="config" --force
+php artisan vendor:publish --provider="Juy\CharacterSolver\ServiceProvider" --tag="config" --force
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "juy/character-solver",
     "description": "Solve some character issue on source code",
+    "keywords": ["laravel", "middleware", "character", "source code"],
     "license": "MIT",
     "type": "library",
     "homepage": "https://github.com/juy/CharacterSolver",

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -61,7 +61,6 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     protected function publishConfig()
     {
-        // php artisan vendor:publish --provider="Juy\Providers\CharacterSolver" --tag="config" --force
         $this->publishes([
             __DIR__.'/../config/charactersolver.php' => config_path('charactersolver.php')
         ], 'config');


### PR DESCRIPTION
- Add keywords section to composer.json
- Fix wrong ServiceProvider name on README
- Add advanced usage section to README
